### PR TITLE
Include html for doc overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,4 @@ coverage.xml
 docs/_build/
 
 wheelhouse/
-*.html
 train/out/

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+{{ super() }}
+<meta name="readthedocs-addons-api-version" content="1" />
+{% endblock %}


### PR DESCRIPTION
We were ignoring html files, but readthedocs needs the HTML file in overrides.